### PR TITLE
remove broken /api/push cURL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ Since Satis repository files can be found under `/` URL path, Satis API endpoint
 PUSH events handler, returns immediately and does not wait for build to finish.
 
 ```
-$ curl -sS -d'url=https://github.com/php-amqplib/php-amqplib' http://your-server:8080/api/push
 $ curl -sS -d'{"repository":{"url":"https://github.com/php-amqplib/php-amqplib"}}' -H'Content-Type: application/json' http://your-server:8080/api/push
 ```
 


### PR DESCRIPTION
This PR removes the first `curl` example command for `/api/push`, which I feel is incorrect after looking at [this line](https://github.com/lukaszlach/satis-server/blob/8fededc4d69f1eef5f03cb692bc3f2b1efc6b56f/webhook/hooks.json#L10) in `hooks.json`. 

From my understanding, `/api/push` will **only** parse a payload of `application/json`, not `application/x-www-form-urlencoded`.

I suppose another option would be to change `hooks.json` so that `/api/push` accepts a plain `url` parameter, much like `/api/build` or `/api/add`.