### PR TITLE
Fixed regular expression not accepting the given ip (cidr notation)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ LABEL maintainer="Łukasz Lach <llach@llach.pl>" \
 ENV SATIS_SERVER_VERSION ${SATIS_SERVER_VERSION:-dev-master}
 WORKDIR /satis-server
 
-RUN apk -U add jq nginx && \
+RUN apk -U add jq nginx tini && \
     rm -rf /var/cache/apk/* /etc/nginx/conf.d/* && \
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config && \
     mkdir -p /root/.ssh/satis-server /etc/webhook

--- a/bin/satis-server.sh
+++ b/bin/satis-server.sh
@@ -9,7 +9,7 @@ cp -fr /satis-server/nginx/* /etc/nginx/
 if [ -f /etc/satis-server/https/cert.pem ] && [ -f /etc/satis-server/https/key.pem ]; then
     sed 's/^#ssl//g; s/$SSL_PORT/'"$SSL_PORT"'/g' -i /etc/nginx/conf.d/*.conf
 fi
-if echo -n "$API_ALLOW" | grep -E "(\d\.)+\d/\d+" > /dev/null; then
+if echo -n "$API_ALLOW" | grep -E "(\d{1,3}\.)+\d{1,3}/\d{1,2}" > /dev/null; then
     sed 's/^#allow//g; s#$API_ALLOW#'"$API_ALLOW"'#g' -i /etc/nginx/conf.d/*.conf
 fi
 if [ ! -z "$PUSH_SECRET" ]; then

--- a/bin/satis-server.sh
+++ b/bin/satis-server.sh
@@ -9,6 +9,9 @@ cp -fr /satis-server/nginx/* /etc/nginx/
 if [ -f /etc/satis-server/https/cert.pem ] && [ -f /etc/satis-server/https/key.pem ]; then
     sed 's/^#ssl//g; s/$SSL_PORT/'"$SSL_PORT"'/g' -i /etc/nginx/conf.d/*.conf
 fi
+if [ -f /etc/satis-server/htpasswd ]; then
+    sed 's/^#auth//g' -i /etc/nginx/conf.d/*.conf
+fi
 if echo -n "$PROXY_IP" | grep -E "(\d{1,3}\.)+\d{1,3}/\d{1,2}" > /dev/null; then
 	sed 's/^#proxy //g; s#$PROXY_IP#'"$PROXY_IP"'#g' -i /etc/nginx/conf.d/*.conf
 fi

--- a/bin/satis-server.sh
+++ b/bin/satis-server.sh
@@ -9,6 +9,9 @@ cp -fr /satis-server/nginx/* /etc/nginx/
 if [ -f /etc/satis-server/https/cert.pem ] && [ -f /etc/satis-server/https/key.pem ]; then
     sed 's/^#ssl//g; s/$SSL_PORT/'"$SSL_PORT"'/g' -i /etc/nginx/conf.d/*.conf
 fi
+if echo -n "$PROXY_IP" | grep -E "(\d{1,3}\.)+\d{1,3}/\d{1,2}" > /dev/null; then
+	sed 's/^#proxy //g; s#$PROXY_IP#'"$PROXY_IP"'#g' -i /etc/nginx/conf.d/*.conf
+fi
 if echo -n "$API_ALLOW" | grep -E "(\d{1,3}\.)+\d{1,3}/\d{1,2}" > /dev/null; then
     sed 's/^#allow//g; s#$API_ALLOW#'"$API_ALLOW"'#g' -i /etc/nginx/conf.d/*.conf
 fi

--- a/nginx/conf.d/satis-server.conf
+++ b/nginx/conf.d/satis-server.conf
@@ -1,3 +1,7 @@
+#proxy set_real_ip_from $PROXY_IP;
+#proxy real_ip_recursive on;
+#proxy real_ip_header X-Forwarded-For;
+
 server {
     listen 80;
 #ssl    listen 443 default ssl;

--- a/nginx/conf.d/satis-server.conf
+++ b/nginx/conf.d/satis-server.conf
@@ -47,6 +47,11 @@ server {
     }
     location / {
         root /etc/satis/output;
+#auth        satisfy any;
+#auth        allow 127.0.0.1;
+#auth        deny all;
+#auth        auth_basic "Satis";
+#auth        auth_basic_user_file /etc/satis-server/htpasswd;
     }
     location ~ ^/(403|500).html {
         root /tmp;


### PR DESCRIPTION
I had a problem that the given ip address didn't end up in the nginx config. This was due to the regexp being to strict. I made a little change so it allows valid combinations.
