### PR TITLE
Add missing package tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ LABEL maintainer="Łukasz Lach <llach@llach.pl>" \
 ENV SATIS_SERVER_VERSION ${SATIS_SERVER_VERSION:-dev-master}
 WORKDIR /satis-server
 
-RUN apk -U add jq nginx && \
+RUN apk -U add jq nginx tini && \
     rm -rf /var/cache/apk/* /etc/nginx/conf.d/* && \
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config && \
     mkdir -p /root/.ssh/satis-server /etc/webhook


### PR DESCRIPTION
In the newer images tini is missing, because docker now supports tini via a command line flag.
But that also needed some rework due to a changed exec path for tini, so I found it easiest (and backwards compatible with older compose installations) to just install tini in the image.